### PR TITLE
Revert "Replicating the fake for empty strings"

### DIFF
--- a/routes/v1/sessions/create.ts
+++ b/routes/v1/sessions/create.ts
@@ -9,13 +9,9 @@ export default withRouteSpec({
     user_id: z.string(),
     host: z.string(),
   }),
-  jsonBody: z.object({
-    body: z.string().optional(),
-  }),
 })((req, ctx) => {
-  if (req.jsonBody.body !== "") {
-    return ctx.json({ id: "", user_id: "", host: "" }, { status: 502 })
-  }
+  // TODO check the body, this endpoint sends a 502 bad gateway
+  // if you don't provide an empty string in the body
 
   const session = {
     session_id: randomUUID(),

--- a/tests/routes/_fake/run-autorouter.test.ts
+++ b/tests/routes/_fake/run-autorouter.test.ts
@@ -20,7 +20,7 @@ test("POST /_fake/run_autorouter", async () => {
   // Create a session
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/jobs/enqueue.test.ts
+++ b/tests/routes/v1/jobs/enqueue.test.ts
@@ -12,7 +12,7 @@ test("POST /v1/jobs/enqueue", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/jobs/get-job.test.ts
+++ b/tests/routes/v1/jobs/get-job.test.ts
@@ -12,7 +12,7 @@ test("GET /v1/jobs/[job_id]", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/jobs/input.test.ts
+++ b/tests/routes/v1/jobs/input.test.ts
@@ -12,7 +12,7 @@ test("POST /v1/jobs/[job_id]/input", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/jobs/list.test.ts
+++ b/tests/routes/v1/jobs/list.test.ts
@@ -12,7 +12,7 @@ test("GET /v1/jobs/list/[session_id]", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/jobs/output.test.ts
+++ b/tests/routes/v1/jobs/output.test.ts
@@ -13,7 +13,7 @@ test.skip("GET /v1/jobs/[job_id]/output", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/jobs/settings.test.ts
+++ b/tests/routes/v1/jobs/settings.test.ts
@@ -12,7 +12,7 @@ test("POST /v1/jobs/[job_id]/settings", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/jobs/start.test.ts
+++ b/tests/routes/v1/jobs/start.test.ts
@@ -12,7 +12,7 @@ test("PUT /v1/jobs/[job_id]/start", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id
@@ -81,7 +81,7 @@ test("PUT /v1/jobs/[job_id]/start - no input file", async () => {
   // Create a session first
   const createSessionRes = await axios.post(
     "/v1/sessions/create",
-    { body: "" },
+    {},
     { headers },
   )
   const sessionId = createSessionRes.data.id

--- a/tests/routes/v1/sessions/create.test.ts
+++ b/tests/routes/v1/sessions/create.test.ts
@@ -9,37 +9,11 @@ test("POST /v1/sessions/create", async () => {
     "Freerouting-Environment-Host": "test-host",
   }
 
-  const { data } = await axios.post(
-    "/v1/sessions/create",
-    {
-      body: "",
-    },
-    { headers },
-  )
+  const { data } = await axios.post("/v1/sessions/create", {}, { headers })
 
   expect(data).toMatchObject({
     id: expect.any(String),
     user_id: "test-user-id",
     host: "test-host",
   })
-})
-
-test("POST /v1/sessions/create with non-empty body returns 502", async () => {
-  const { axios } = await getTestServer()
-
-  const headers = {
-    "Freerouting-Profile-ID": "test-user-id",
-    "Freerouting-Environment-Host": "test-host",
-  }
-
-  const response = await axios.post(
-    "/v1/sessions/create",
-    { some: "data" },
-    {
-      headers,
-      validateStatus: () => true,
-    },
-  )
-
-  expect(response.status).toBe(502)
 })

--- a/tests/routes/v1/sessions/get-session.test.ts
+++ b/tests/routes/v1/sessions/get-session.test.ts
@@ -10,11 +10,7 @@ test("GET /v1/sessions/[session_id]", async () => {
   }
 
   // Create a session first
-  const createRes = await axios.post(
-    "/v1/sessions/create",
-    { body: "" },
-    { headers },
-  )
+  const createRes = await axios.post("/v1/sessions/create", {}, { headers })
   const sessionId = createRes.data.id
 
   // Get specific session

--- a/tests/routes/v1/sessions/list.test.ts
+++ b/tests/routes/v1/sessions/list.test.ts
@@ -10,11 +10,7 @@ test("GET /v1/sessions/list", async () => {
   }
 
   // Create a session first
-  const createRes = await axios.post(
-    "/v1/sessions/create",
-    { body: "" },
-    { headers },
-  )
+  const createRes = await axios.post("/v1/sessions/create", {}, { headers })
   const sessionId = createRes.data.id
 
   // Get list of sessions


### PR DESCRIPTION
Reverts tscircuit/fake-freerouting#12

This version is breaking the `registry-api`
<img width="1637" alt="Screenshot 2024-11-22 at 03 03 31" src="https://github.com/user-attachments/assets/62cb2007-a570-43cd-9138-3a3a9fd9942f">
