### PR TITLE
Validation that the sticky session works

### DIFF
--- a/tests/routes/_fake/internal-freerouter-sticky-session.test.ts
+++ b/tests/routes/_fake/internal-freerouter-sticky-session.test.ts
@@ -54,6 +54,11 @@ test("Testing sticky session of internal-freerouter", async () => {
 })
 
 test("Testing sticky session of internal-freerouter to fail ", async () => {
+  if (process.env.CI) {
+    console.log("Skipping test in CI")
+    return
+  }
+
   const axios = defaultAxios.create({
     baseURL: "https://internal-freerouting-personal.fly.dev",
   })


### PR DESCRIPTION
I don't think we need to merge this as it uses hard coded machine id's, it is just to validate that the sticky sessions work. 

<img width="1507" alt="Screenshot 2024-12-26 at 18 59 33" src="https://github.com/user-attachments/assets/75f30060-f2c9-41d8-8bde-88829f2d4b04" />

@seveibar 